### PR TITLE
feat(versions): add version handlers

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,0 +1,13 @@
+print("Loading .busted configuration...")
+
+return {
+    default = {
+        root = "src",
+        pattern = "**/*_spec.lua$",
+        helper = "spec/setup.lua",
+        verbose = true,
+        coverage = true,
+        output = "utfTerminal",
+        jobs = 4,
+    }
+}

--- a/.github/workflows/build_test_evolve.yaml
+++ b/.github/workflows/build_test_evolve.yaml
@@ -43,8 +43,9 @@ jobs:
   evolve:
     # Run on main branch only
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    needs: integration
+    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'
+    needs: [integration, unit]
+    environment: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.2

--- a/.github/workflows/build_test_evolve.yaml
+++ b/.github/workflows/build_test_evolve.yaml
@@ -3,7 +3,31 @@ name: Build and Test
 on: [push, workflow_dispatch]
 
 jobs:
-  # TODO: add unit tests using bused
+  unit:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        name: Check out repository code
+
+      - name: Setup Lua
+        uses: leafo/gh-actions-lua@v10
+        with:
+          luaVersion: '5.3' # Specify the Lua version you need
+
+      - name: Setup LuaRocks
+
+        uses: leafo/gh-actions-luarocks@v4.3.0
+
+      - name: Install Busted
+        run: luarocks install ar-io-ant-registry-0.1-1.rockspec
+
+      - name: Run Busted Tests
+        run: busted .
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
   integration:
     runs-on: ubuntu-latest
     steps:
@@ -15,7 +39,7 @@ jobs:
 
       - run: yarn --frozen-lockfile
       - run: yarn aos:build
-      - run: yarn test
+      - run: yarn test:integration
   evolve:
     # Run on main branch only
     runs-on: ubuntu-latest

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,7 @@
+allow_defined = true
+exclude_files = {}
+globals = {
+	"Handlers",
+	"ao",
+}
+max_line_length = 185

--- a/.luacov
+++ b/.luacov
@@ -1,0 +1,5 @@
+statsfile = 'coverage/luacov.stats.out';
+reportfile = 'coverage/luacov.report.out';
+deleteStatsFile = false;
+include = { "src/" }
+exclude = { "crypto", "json", "base64" }

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,21 @@
+{
+  "Lua": {
+    "runtime": {
+      "version": "5.3",
+      "path": ["?.lua", "?/init.lua"]
+    },
+    "workspace": {
+      "library": [
+        "src",
+        "spec",
+        "${addons}/busted/module/library",
+        "${3rd}/luassert/library"
+      ]
+    },
+    "diagnostics": {
+      "enable": true,
+      "globals": []
+    }
+  },
+  "workspace.checkThirdParty": false
+}

--- a/ar-io-ant-registry-0.1-1.rockspec
+++ b/ar-io-ant-registry-0.1-1.rockspec
@@ -2,7 +2,7 @@ package = "ar-io-ant-registry"
 version = "0.1-1"
 rockspec_format = "3.0"
 source = {
-    url = "./src/main.lua"
+    url = "./src/common/main.lua"
 }
 dependencies = {
     "busted >= 2.2.0",

--- a/ar-io-ant-registry-0.1-1.rockspec
+++ b/ar-io-ant-registry-0.1-1.rockspec
@@ -1,0 +1,15 @@
+package = "ar-io-ant-registry"
+version = "0.1-1"
+rockspec_format = "3.0"
+source = {
+    url = "./src/main.lua"
+}
+dependencies = {
+    "busted >= 2.2.0",
+    "luacov >= 0.15.0",
+    "luacheck >= 1.1.2",
+    "luacov-html >=1.0.0"
+}
+test = {
+  type = "busted",
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "aos:publish": "node tools/bundle-aos.js && node tools/publish-aos.js",
     "aos:load": "node tools/bundle-aos.js && node tools/load-aos.js",
     "aos:spawn": "node tools/spawn-aos.js",
-    "test": "node --test-concurrency 1 --experimental-wasm-memory64 **/*.test.js",
+    "test:unit": "busted .",
+    "test:integration": "node --test --experimental-wasm-memory64 **/*.test.js",
+    "test": "yarn test:unit && yarn test:integration",
     "evolve": "yarn aos:build && node tools/evolve.js"
   },
   "devDependencies": {

--- a/spec/setup.lua
+++ b/spec/setup.lua
@@ -1,0 +1,24 @@
+package.path = "spec/?.lua;spec/?/init.lua;" .. package.path
+
+_G.ao = {
+	send = function(val)
+		return val
+	end,
+	id = "test",
+	env = {
+		Process = {
+			Id = "test",
+			Owner = "test",
+		},
+	},
+}
+
+_G.Handlers = {
+	utils = {
+		reply = function()
+			return true
+		end,
+	},
+}
+
+print("Setup global ao mocks successfully...")

--- a/spec/utils_spec.lua
+++ b/spec/utils_spec.lua
@@ -2,45 +2,6 @@
 local utils = require(".common.utils")
 
 describe("utils.lua", function()
-	describe("utils.validateSemver", function()
-		local validVersions = {
-			"1.0.0",
-			"0.1.0",
-			"1.2.3",
-			"10.20.30",
-			"1.0.0-alpha",
-			"1.0.0-beta.2",
-			"9223372036854775807.0.0", -- Added to test large numbers
-		}
-
-		for _, version in ipairs(validVersions) do
-			it(string.format("should accept valid version: %s", version), function()
-				assert.has_no.errors(function()
-					utils.validateSemver(version)
-				end)
-			end)
-		end
-
-		local invalidVersions = {
-			["incomplete version string missing patch"] = "1.0",
-			["incomplete version string missing minor and patch"] = "1",
-			["too many version segments"] = "1.0.0.0",
-			["contains invalid prefix"] = "v1.0.0",
-			["build metadata not supported"] = "1.0.0+build",
-			["invalid version format"] = "not.a.version",
-			["empty string"] = "",
-			["non-string input"] = 123,
-			["nil input"] = nil,
-		}
-
-		for reason, version in pairs(invalidVersions) do
-			it(string.format("should reject invalid version: %s (%s)", tostring(version), reason), function()
-				assert.has.errors(function()
-					utils.validateSemver(version)
-				end)
-			end)
-		end
-	end)
 	describe("utils.validateArweaveId", function()
 		it("should throw an error for invalid Arweave IDs", function()
 			local invalid = utils.validateArweaveId("invalid-arweave-id-123")

--- a/spec/utils_spec.lua
+++ b/spec/utils_spec.lua
@@ -1,0 +1,55 @@
+-- spec/utils_spec.lua
+local utils = require(".common.utils")
+
+describe("utils.lua", function()
+	describe("utils.validateSemver", function()
+		local validVersions = {
+			"1.0.0",
+			"0.1.0",
+			"1.2.3",
+			"10.20.30",
+			"1.0.0-alpha",
+			"1.0.0-beta.2",
+			"9223372036854775807.0.0", -- Added to test large numbers
+		}
+
+		for _, version in ipairs(validVersions) do
+			it(string.format("should accept valid version: %s", version), function()
+				assert.has_no.errors(function()
+					utils.validateSemver(version)
+				end)
+			end)
+		end
+
+		local invalidVersions = {
+			["incomplete version string missing patch"] = "1.0",
+			["incomplete version string missing minor and patch"] = "1",
+			["too many version segments"] = "1.0.0.0",
+			["contains invalid prefix"] = "v1.0.0",
+			["build metadata not supported"] = "1.0.0+build",
+			["invalid version format"] = "not.a.version",
+			["empty string"] = "",
+			["non-string input"] = 123,
+			["nil input"] = nil,
+		}
+
+		for reason, version in pairs(invalidVersions) do
+			it(string.format("should reject invalid version: %s (%s)", tostring(version), reason), function()
+				assert.has.errors(function()
+					utils.validateSemver(version)
+				end)
+			end)
+		end
+	end)
+	describe("utils.validateArweaveId", function()
+		it("should throw an error for invalid Arweave IDs", function()
+			local invalid = utils.validateArweaveId("invalid-arweave-id-123")
+			assert.is_false(invalid)
+		end)
+
+		it("should not throw an error for a valid Arweave ID", function()
+			local valid = utils.validateArweaveId("0E7Ai_rEQ326_vLtgB81XHViFsLlcwQNqlT9ap24uQI")
+			assert.is_true(valid)
+		end)
+	end)
+end)

--- a/src/common/main.lua
+++ b/src/common/main.lua
@@ -16,10 +16,20 @@ main.init = function()
 	-- ADDRESSES["userAddress"] = {"antProcessId1" = true, "antProcessId2" = true}
 	ADDRESSES = ADDRESSES or {}
 
+	ANTVersions = ANTVersions
+		or {
+			["1.0.0"] = {
+				module = "pb4fCvdJqwT-_bn38ERMdqnOF4weRMjoJ6bY6yfl4a8",
+				luaSource = "OO2ewZKq4AHoqGQmYUIl-NhJ-llQyFJ3ha4Uf4-w5RI",
+			},
+		}
+
 	local ActionMap = {
 		Register = "Register",
 		StateNotice = "State-Notice",
 		AccessControlList = "Access-Control-List",
+		AddVersion = "Add-Version",
+		GetVersions = "Get-Versions",
 	}
 
 	utils.createActionHandler(ActionMap.Register, function(msg)
@@ -52,6 +62,41 @@ main.init = function()
 			Action = "Access-Control-List-Notice",
 			["Message-Id"] = msg.Id,
 			Data = json.encode(utils.affiliationsForAddress(address, ANTS)),
+		})
+	end)
+
+	utils.createActionHandler(ActionMap.AddVersion, function(msg)
+		assert(msg.From == Owner, "Only ANT Registry owner can add versions")
+		local version = msg.Version
+		local module = msg["Module-Id"]
+		local luaSource = msg["Lua-Source-Id"]
+
+		utils.validateSemver(version)
+		utils.validateArweaveId(module)
+		assert(
+			type(luaSource) == "string" and utils.validateArweaveId(luaSource) or luaSource == nil,
+			"Lua-Source-Id should be a valid arweave ID"
+		)
+		assert(not ANTVersions[version], "Version " .. tostring(version) .. " already exists")
+
+		local newVersionData = { module = module, luaSource = luaSource }
+
+		ANTVersions[version] = newVersionData
+
+		ao.send({
+			Target = msg.From,
+			Action = "Add-Version-Notice",
+			["Message-Id"] = msg.Id,
+			Data = json.encode(ANTVersions),
+		})
+	end)
+
+	utils.createActionHandler(ActionMap.GetVersions, function(msg)
+		ao.send({
+			Target = msg.From,
+			Action = "Get-Versions-Notice",
+			["Message-Id"] = msg.Id,
+			Data = json.encode(ANTVersions),
 		})
 	end)
 end

--- a/src/common/main.lua
+++ b/src/common/main.lua
@@ -23,6 +23,7 @@ main.init = function()
 		StateNotice = "State-Notice",
 		AccessControlList = "Access-Control-List",
 		AddVersion = "Add-Version",
+		RemoveVersion = "Remove-Version",
 		GetVersions = "Get-Versions",
 	}
 
@@ -83,6 +84,21 @@ main.init = function()
 		ao.send({
 			Target = msg.From,
 			Action = "Add-Version-Notice",
+			["Message-Id"] = msg.Id,
+			Data = json.encode(ANTVersions),
+		})
+	end)
+
+	utils.createActionHandler(ActionMap.RemoveVersion, function(msg)
+		assert(msg.From == Owner, "Only ANT Registry owner can add versions")
+		local version = tostring(msg.Version)
+
+		assert(ANTVersions[version], "Version " .. version .. " does not exist")
+
+		ANTVersions[version] = nil
+		ao.send({
+			Target = msg.From,
+			Action = "Remove-Version-Notice",
 			["Message-Id"] = msg.Id,
 			Data = json.encode(ANTVersions),
 		})

--- a/src/common/main.lua
+++ b/src/common/main.lua
@@ -16,13 +16,7 @@ main.init = function()
 	-- ADDRESSES["userAddress"] = {"antProcessId1" = true, "antProcessId2" = true}
 	ADDRESSES = ADDRESSES or {}
 
-	ANTVersions = ANTVersions
-		or {
-			["1.0.0"] = {
-				module = "pb4fCvdJqwT-_bn38ERMdqnOF4weRMjoJ6bY6yfl4a8",
-				luaSource = "OO2ewZKq4AHoqGQmYUIl-NhJ-llQyFJ3ha4Uf4-w5RI",
-			},
-		}
+	ANTVersions = ANTVersions or {}
 
 	local ActionMap = {
 		Register = "Register",
@@ -67,21 +61,24 @@ main.init = function()
 
 	utils.createActionHandler(ActionMap.AddVersion, function(msg)
 		assert(msg.From == Owner, "Only ANT Registry owner can add versions")
-		local version = msg.Version
-		local module = msg["Module-Id"]
-		local luaSource = msg["Lua-Source-Id"]
+		local version = tonumber(msg.Version)
+		local moduleId = msg["Module-Id"]
+		local luaSourceId = msg["Lua-Source-Id"]
+		local notes = msg.Notes or ""
 
-		utils.validateSemver(version)
-		utils.validateArweaveId(module)
 		assert(
-			type(luaSource) == "string" and utils.validateArweaveId(luaSource) or luaSource == nil,
+			version ~= nil and math.type(version) == "integer" and version >= 0,
+			"Version must be a positive integer, recieved " .. tostring(version)
+		)
+		utils.validateArweaveId(moduleId)
+		assert(
+			type(luaSourceId) == "string" and utils.validateArweaveId(luaSourceId) or luaSourceId == nil,
 			"Lua-Source-Id should be a valid arweave ID"
 		)
-		assert(not ANTVersions[version], "Version " .. tostring(version) .. " already exists")
+		assert(type(notes) == "string", "Notes must be a string")
 
-		local newVersionData = { module = module, luaSource = luaSource }
-
-		ANTVersions[version] = newVersionData
+		ANTVersions[tostring(version)] =
+			{ messageId = msg.Id, moduleId = moduleId, luaSourceId = luaSourceId, notes = notes }
 
 		ao.send({
 			Target = msg.From,

--- a/src/common/utils.lua
+++ b/src/common/utils.lua
@@ -333,37 +333,6 @@ function utils.affiliationsForAddress(address, ants)
 	return affiliations
 end
 
---- @param versionString string
-function utils.validateSemver(versionString)
-	assert(type(versionString) == "string", "Version must be a string")
-
-	-- Reject versions with build metadata (anything after +)
-	if versionString:find("%+") then
-		error("Build metadata is not supported: " .. versionString)
-	end
-
-	-- The pattern now ensures there are exactly 3 version segments
-	-- and optionally a prerelease identifier
-	local pattern = "^(%d+)%.(%d+)%.(%d+)$"
-	local prereleasePattern = "^(%d+)%.(%d+)%.(%d+)%-([%w%.%-]+)$"
-
-	local hasMatch = versionString:match(pattern) or versionString:match(prereleasePattern)
-	if not hasMatch then
-		error("Invalid semver string: " .. versionString)
-	end
-
-	-- If we have a prerelease version, validate its format
-	local prerelease = versionString:match("^%d+%.%d+%.%d+%-([%w%.%-]+)$")
-	if prerelease then
-		assert(
-			prerelease:match("^[%w%.%-]+$"),
-			"Prerelease identifier must only contain letters, numbers, dots, and hyphens"
-		)
-	end
-
-	return versionString
-end
-
 --- Checks if an address is a valid Arweave address
 --- @param address string The address to check
 --- @return boolean isValidArweaveAddress - whether the address is a valid Arweave address

--- a/src/common/utils.lua
+++ b/src/common/utils.lua
@@ -333,4 +333,42 @@ function utils.affiliationsForAddress(address, ants)
 	return affiliations
 end
 
+--- @param versionString string
+function utils.validateSemver(versionString)
+	assert(type(versionString) == "string", "Version must be a string")
+
+	-- Reject versions with build metadata (anything after +)
+	if versionString:find("%+") then
+		error("Build metadata is not supported: " .. versionString)
+	end
+
+	-- The pattern now ensures there are exactly 3 version segments
+	-- and optionally a prerelease identifier
+	local pattern = "^(%d+)%.(%d+)%.(%d+)$"
+	local prereleasePattern = "^(%d+)%.(%d+)%.(%d+)%-([%w%.%-]+)$"
+
+	local hasMatch = versionString:match(pattern) or versionString:match(prereleasePattern)
+	if not hasMatch then
+		error("Invalid semver string: " .. versionString)
+	end
+
+	-- If we have a prerelease version, validate its format
+	local prerelease = versionString:match("^%d+%.%d+%.%d+%-([%w%.%-]+)$")
+	if prerelease then
+		assert(
+			prerelease:match("^[%w%.%-]+$"),
+			"Prerelease identifier must only contain letters, numbers, dots, and hyphens"
+		)
+	end
+
+	return versionString
+end
+
+--- Checks if an address is a valid Arweave address
+--- @param address string The address to check
+--- @return boolean isValidArweaveAddress - whether the address is a valid Arweave address
+function utils.validateArweaveId(address)
+	return type(address) == "string" and #address == 43 and string.match(address, "^[%w-_]+$") ~= nil
+end
+
 return utils

--- a/test/versions.test.js
+++ b/test/versions.test.js
@@ -1,0 +1,212 @@
+import assert from 'node:assert';
+import { describe, it, before } from 'node:test';
+import { createAntAosLoader } from './utils.js';
+import {
+  AO_LOADER_HANDLER_ENV,
+  DEFAULT_HANDLE_OPTIONS,
+  STUB_ADDRESS,
+} from '../tools/constants.js';
+
+describe('ANT Versions', async () => {
+  let handle;
+  let startMemory;
+
+  before(async () => {
+    const loader = await createAntAosLoader();
+    handle = loader.handle;
+    startMemory = loader.memory;
+  });
+
+  async function sendMessage(options = {}, mem = startMemory) {
+    return handle(
+      mem,
+      {
+        ...DEFAULT_HANDLE_OPTIONS,
+        ...options,
+      },
+      AO_LOADER_HANDLER_ENV,
+    );
+  }
+
+  async function addVersion(
+    moduleId,
+    luaSourceId,
+    semver,
+    from = STUB_ADDRESS,
+    mem = startMemory,
+  ) {
+    const addVersionRes = await sendMessage(
+      {
+        From: from, // process owner or non-owner
+        Tags: [
+          { name: 'Action', value: 'Add-Version' },
+          { name: 'Module-Id', value: moduleId },
+          { name: 'Lua-Source-Id', value: luaSourceId },
+          { name: 'Version', value: semver },
+        ],
+      },
+      mem,
+    );
+
+    return addVersionRes;
+  }
+
+  async function getVersions(mem) {
+    return await sendMessage(
+      {
+        Tags: [{ name: 'Action', value: 'Get-Versions' }],
+      },
+      mem,
+    );
+  }
+
+  const validModuleIds = [
+    'module-id-'.padEnd(43, '1'),
+    'another-module-id-'.padEnd(43, '1'),
+  ];
+  const validSourceIds = [
+    'lua-source-id-'.padEnd(43, '1'),
+    'another-lua-source-id-'.padEnd(43, '1'),
+    undefined,
+  ];
+  const validSemvers = [
+    '1.0.1',
+    '2.0.0',
+    '0.1.0',
+    '1.2.3',
+    '10.20.30',
+    '1.0.0-alpha',
+    '1.0.0-beta.2',
+    '9223372036854775807.0.0',
+  ];
+
+  const testCaseMapping = validModuleIds.flatMap((moduleId) =>
+    validSourceIds.flatMap((luaSourceId) =>
+      validSemvers.map((semver) => ({ moduleId, luaSourceId, semver })),
+    ),
+  );
+
+  testCaseMapping.forEach((testCase) => {
+    it(`should add version correctly for module id: ${testCase.moduleId}, lua source id: ${testCase.luaSourceId}, semver: ${testCase.semver}`, async () => {
+      const getVersionsResBefore = await getVersions();
+      const versionsBefore = JSON.parse(getVersionsResBefore.Messages[0].Data);
+      const addVersionRes = await addVersion(
+        testCase.moduleId,
+        testCase.luaSourceId,
+        testCase.semver,
+      );
+      const addVersionNotice = addVersionRes.Messages.find((m) =>
+        m.Tags.find((t) => t.value === 'Add-Version-Notice'),
+      );
+      assert(addVersionNotice, 'Did not recieve add version notice');
+      const getVersionsResAfter = await getVersions(addVersionRes.Memory);
+      const versionsAfter = JSON.parse(getVersionsResAfter.Messages[0].Data);
+
+      assert(
+        versionsAfter[testCase.semver],
+        `Version ${testCase.semver} was not added`,
+      );
+      assert.strictEqual(
+        versionsAfter[testCase.semver].module,
+        testCase.moduleId,
+        'Module ID does not match',
+      );
+      assert.strictEqual(
+        versionsAfter[testCase.semver].luaSource,
+        testCase.luaSourceId,
+        'Lua Source ID does not match',
+      );
+      const versionsAfterExcludingAdded = { ...versionsAfter };
+      delete versionsAfterExcludingAdded[testCase.semver];
+      assert.deepStrictEqual(
+        versionsAfterExcludingAdded,
+        versionsBefore,
+        'Pre-existing versions were changed',
+      );
+    });
+  });
+
+  const invalidModuleIds = [
+    'invalid-module-id', // too short
+    'module-id-too-long-'.padEnd(44, '1'), // too long
+    'module-id-with-invalid-characters-'.padEnd(43, '1'), // contains invalid characters
+  ];
+
+  invalidModuleIds.forEach((invalidModuleId) => {
+    it(`should reject invalid module id: ${invalidModuleId}`, async () => {
+      const addVersionRes = await addVersion(
+        invalidModuleId,
+        validSourceIds[0],
+        validSemvers[0],
+        'non-owner-address',
+      );
+      assert(
+        !addVersionRes.Messages.find((m) =>
+          m.Tags.find((t) => t.value === 'Add-Version-Notice'),
+        ),
+        'Add version notice sent by non-process-owner',
+      );
+    });
+  });
+  const invalidSourceIds = [
+    'invalid-lua-source-id', // too short
+    'lua-source-id-too-long-'.padEnd(44, '1'), // too long
+    'lua-source-id-with-invalid-characters-'.padEnd(43, '1'), // contains invalid characters
+  ];
+
+  invalidSourceIds.forEach((invalidSourceId) => {
+    it(`should reject invalid lua source id: ${invalidSourceId}`, async () => {
+      const addVersionRes = await addVersion(
+        validModuleIds[0],
+        invalidSourceId,
+        validSemvers[0],
+        'non-owner-address',
+      );
+      assert(
+        !addVersionRes.Messages.find((m) =>
+          m.Tags.find((t) => t.value === 'Add-Version-Notice'),
+        ),
+        'Add version notice sent by non-process-owner',
+      );
+    });
+  });
+
+  const invalidSemvers = [
+    '1.0', // missing patch
+    '1', // missing minor and patch
+    '1.0.0.0', // too many segments
+    'v1.0.0', // contains invalid prefix
+    '1.0.0+build', // build metadata not supported
+    'not.a.version', // invalid format
+    '', // empty string
+    123, // non-string input
+    null, // null input
+  ];
+
+  invalidSemvers.forEach((invalidSemver) => {
+    it(`should reject invalid semver: ${invalidSemver}`, async () => {
+      const addVersionRes = await addVersion(
+        validModuleIds[0],
+        validSourceIds[0],
+        invalidSemver,
+        'non-owner-address',
+      );
+      assert(
+        !addVersionRes.Messages.find((m) =>
+          m.Tags.find((t) => t.value === 'Add-Version-Notice'),
+        ),
+        'Non process owner added a version',
+      );
+
+      // Check that the version was not added
+      const getVersionsRes = await getVersions(
+        invalidSemver,
+        addVersionRes.Memory,
+      );
+      assert(
+        !JSON.parse(getVersionsRes.Messages[0].Data)[invalidSemver],
+        `Version ${invalidSemver} was incorrectly added`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Adds:
- Add-Version handler (Owner only).
- Get-Versions handler (public) that returns all the versions.
- ANTVersions table, index by semver, with`module` and `luaSource` ids pointing the the published source codes.
- Busted testing and luarocks configs.
... more integration tests and started some unit tests.

