### PR TITLE
fix(PE-7893): add lastUpdatedAt timestamp to ant mapping

### DIFF
--- a/src/common/main.lua
+++ b/src/common/main.lua
@@ -44,7 +44,7 @@ main.init = function()
 
 	utils.createActionHandler(ActionMap.StateNotice, function(msg)
 		local ant = utils.parseAntState(msg.Data)
-		utils.updateAffiliations(msg.From, ant, ADDRESSES, ANTS)
+		utils.updateAffiliations(msg.From, ant, ADDRESSES, ANTS, tonumber(msg.Timestamp))
 	end)
 
 	utils.createActionHandler(ActionMap.AccessControlList, function(msg)

--- a/src/common/utils.lua
+++ b/src/common/utils.lua
@@ -227,13 +227,18 @@ function utils.controllerTableFromArray(t)
 	return map
 end
 
-function utils.updateAffiliations(antId, newAnt, addresses, ants)
+function utils.updateAffiliations(antId, newAnt, addresses, ants, currentTimestamp)
 	-- Remove previous affiliations for old owner and controllers
 	local maybeOldAnt = ants[antId]
 	local newAffliates = utils.affiliatesForAnt(newAnt)
 
 	-- Remove stale address affiliations
 	if maybeOldAnt ~= nil then
+		local lastUpdatedAt = maybeOldAnt.lastUpdatedAt
+		assert(
+			lastUpdatedAt == nil or lastUpdatedAt <= currentTimestamp,
+			"Last updated timestamp is greater than the current timestamp"
+		)
 		local oldAffliates = utils.affiliatesForAnt(maybeOldAnt)
 		for oldAffliate, _ in pairs(oldAffliates) do
 			if not newAffliates[oldAffliate] and addresses[oldAffliate] then
@@ -255,6 +260,7 @@ function utils.updateAffiliations(antId, newAnt, addresses, ants)
 		ants[antId] = nil
 	else
 		ants[antId] = newAnt
+		ants[antId].lastUpdatedAt = currentTimestamp
 	end
 end
 

--- a/test/register.test.js
+++ b/test/register.test.js
@@ -100,4 +100,95 @@ describe('ANT Registration Cases', async () => {
     );
     assert.strictEqual(failureNotice.value, 'Invalid-State-Notice-Notice');
   });
+
+  it('should handle timestamp ordering correctly', async () => {
+    const antId1 = ''.padEnd(43, 'timestamp-test-1');
+    const antId2 = ''.padEnd(43, 'timestamp-test-2');
+
+    // First state notice with initial timestamp
+    const stateData1 = JSON.stringify({
+      Owner: STUB_ADDRESS,
+      Controllers: [STUB_ADDRESS],
+      Name: 'Ant1',
+      Ticker: 'ANT1',
+    });
+
+    // initialize with a nil lastUpdatedAt timestamp - migration purposes
+    const result0 = await sendMessage({
+      Tags: [{ name: 'Action', value: 'Eval' }],
+      Data: `ANTS['${antId1}'] = { Owner: '${STUB_ADDRESS}', Controllers: {'${STUB_ADDRESS}'} }`,
+      Timestamp: 0,
+    });
+
+    const result1 = await sendMessage(
+      {
+        Tags: [{ name: 'Action', value: 'State-Notice' }],
+        Data: stateData1,
+        From: antId1,
+        Owner: antId1,
+        Timestamp: 1000,
+      },
+      result0.Memory,
+    );
+
+    // Second state notice with later timestamp
+    const stateData2 = JSON.stringify({
+      Owner: STUB_ADDRESS,
+      Controllers: [STUB_ADDRESS],
+      Name: 'Ant2',
+      Ticker: 'ANT2',
+    });
+
+    const result2 = await sendMessage(
+      {
+        Tags: [{ name: 'Action', value: 'State-Notice' }],
+        Data: stateData2,
+        From: antId2,
+        Owner: antId2,
+        Timestamp: 2000,
+      },
+      result1.Memory,
+    );
+
+    // Try to update first ANT with an earlier timestamp (should fail)
+    const updatedStateData1 = JSON.stringify({
+      Owner: STUB_ADDRESS,
+      Controllers: [STUB_ADDRESS],
+      Name: 'Ant1Updated',
+      Ticker: 'ANT1',
+    });
+
+    const failedUpdate = await sendMessage(
+      {
+        Tags: [{ name: 'Action', value: 'State-Notice' }],
+        Data: updatedStateData1,
+        From: antId1,
+        Owner: antId1,
+        Timestamp: 500, // Earlier timestamp
+      },
+      result2.Memory,
+    );
+
+    // Should have an error message
+    assert.strictEqual(failedUpdate.Messages.length, 1);
+    const failureAction = failedUpdate.Messages[0].Tags.find(
+      (tag) => tag.name === 'Action',
+    );
+    assert.strictEqual(failureAction.value, 'Invalid-State-Notice-Notice');
+
+    // Successful update with later timestamp
+    const successUpdate = await sendMessage(
+      {
+        Tags: [{ name: 'Action', value: 'State-Notice' }],
+        Data: updatedStateData1,
+        From: antId1,
+        Owner: antId1,
+        Timestamp: 3000, // Later timestamp
+      },
+      result2.Memory,
+    );
+
+    // Should not have any error messages
+    assert.strictEqual(successUpdate.Messages.length, 0);
+  });
 });


### PR DESCRIPTION
Intended to ensure overwriting on late-cranked messages from the ANT with old state.
